### PR TITLE
Remove useless things in AndroidManifest

### DIFF
--- a/cardstack/src/main/AndroidManifest.xml
+++ b/cardstack/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest package="com.loopeer.cardstack"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        >
-
-    </application>
-
-</manifest>
+<manifest package="com.loopeer.cardstack" />


### PR DESCRIPTION
The manifest merger merges nodes of the library into the app's manifest, but if `supportsRtl="false"` is written in the app's manifest, build error will occurs because library set them as `"true"`.

We can override this behavior with `tools:replace="android:allowBackup,android:supportsRtl"`,
but it is better to remove those attrs from library if it does not needs them really.
